### PR TITLE
Add 16 new actions to GAS Bridge (14 → 30 total)

### DIFF
--- a/bridge/Code.js
+++ b/bridge/Code.js
@@ -1,0 +1,299 @@
+/*
+ * GAS Bridge — Turn Google Apps Script Into a Key-Based API
+ *
+ * Deploys as a Web App and exposes Google Workspace services (Gmail, Drive,
+ * Sheets, Calendar, Docs, Contacts, Translate, Tasks) via simple JSON POST
+ * requests. Authentication uses a shared secret key stored in Script Properties.
+ *
+ * Setup:
+ *   1. Copy this file into your Apps Script project as Code.gs
+ *   2. Run Bridge.initKey() from the editor — copy the key from the Execution Log
+ *   3. Run Bridge.activateScopes() to authorize Google services you need
+ *   4. Deploy > New Deployment > Web App > Execute as: Me, Access: Anyone
+ *   5. POST JSON to the deployment URL: {"action": "info", "key": "YOUR_KEY"}
+ *
+ * Updating:
+ *   Deploy > Manage Deployments > Edit > Version: New Version > Deploy
+ *   (The deployment URL stays the same.)
+ *
+ * Security:
+ *   Every POST request must include a valid key. Generate one with Bridge.initKey().
+ *   Keys are stored in Script Properties (not in source code). Rotate your key
+ *   regularly — this is a shared-secret scheme, not OAuth. Anyone with the key
+ *   and the deployment URL has access to whichever Google services are enabled.
+ */
+
+var Bridge = (function() {
+
+  // --- Web App Entry Points ---
+
+  function doGet(e) {
+    return ContentService.createTextOutput('GAS Bridge is running.')
+      .setMimeType(ContentService.MimeType.TEXT);
+  }
+
+  function doPost(e) {
+    try {
+      var req = JSON.parse(e.postData.contents);
+      var storedKey = PropertiesService.getScriptProperties().getProperty('BRIDGE_KEY');
+      if (!storedKey || req.key !== storedKey) {
+        return _json({error: 'unauthorized'});
+      }
+
+      var handler = HANDLERS[req.action || ''];
+      if (!handler) {
+        return _json({error: 'unknown action', available: Object.keys(HANDLERS)});
+      }
+      return handler(req);
+    } catch (err) {
+      return _json({error: err.message});
+    }
+  }
+
+  // --- Action Handlers ---
+
+  var HANDLERS = {
+    'info':            _info,
+    'gmail.send':      _gmailSend,
+    'gmail.check':     _gmailCheck,
+    'sheets.read':     _sheetsRead,
+    'sheets.append':   _sheetsAppend,
+    'drive.list':      _driveList,
+    'drive.create':    _driveCreate,
+    'calendar.list':   _calendarList,
+    'docs.create':     _docsCreate,
+    'contacts.list':   _contactsList,
+    'tasks.list':      _tasksList,
+    'translate':       _translate,
+    'fetch':           _fetch,
+    'token.get':       _tokenGet,
+  };
+
+  // --- Info ---
+
+  function _info(req) {
+    return _json({
+      service: 'GAS Bridge',
+      version: '1.0',
+      account: Session.getActiveUser().getEmail(),
+      actions: Object.keys(HANDLERS),
+      timestamp: new Date().toISOString()
+    });
+  }
+
+  // --- Gmail ---
+
+  function _gmailSend(req) {
+    if (!req.to) return _json({error: 'missing "to"'});
+    var opts = {};
+    if (req.cc) opts.cc = req.cc;
+    if (req.bcc) opts.bcc = req.bcc;
+    if (req.html) opts.htmlBody = req.body;
+    if (req.replyTo) opts.replyTo = req.replyTo;
+    GmailApp.sendEmail(req.to, req.subject || '(no subject)', req.body || '', opts);
+    return _json({status: 'sent', to: req.to, subject: req.subject});
+  }
+
+  function _gmailCheck(req) {
+    var threads = GmailApp.search(req.query || 'is:unread', 0, req.count || 5);
+    var results = threads.map(function(thread) {
+      var msg = thread.getMessages()[thread.getMessageCount() - 1];
+      return {
+        id: thread.getId(),
+        subject: msg.getSubject(),
+        from: msg.getFrom(),
+        date: msg.getDate().toISOString(),
+        snippet: msg.getPlainBody().substring(0, 300),
+        unread: thread.isUnread()
+      };
+    });
+    return _json({messages: results, count: results.length});
+  }
+
+  // --- Sheets ---
+
+  function _sheetsRead(req) {
+    if (!req.spreadsheet_id) return _json({error: 'missing spreadsheet_id'});
+    var data = SpreadsheetApp.openById(req.spreadsheet_id)
+      .getRange(req.range || 'Sheet1!A1:Z100').getValues();
+    while (data.length > 0 && data[data.length - 1].every(function(c) { return c === ''; })) data.pop();
+    return _json({rows: data, count: data.length});
+  }
+
+  function _sheetsAppend(req) {
+    if (!req.spreadsheet_id) return _json({error: 'missing spreadsheet_id'});
+    if (!req.rows || !req.rows.length) return _json({error: 'no rows'});
+    var sheet = SpreadsheetApp.openById(req.spreadsheet_id).getSheetByName(req.sheet || 'Sheet1');
+    if (!sheet) return _json({error: 'sheet not found'});
+    req.rows.forEach(function(row) { sheet.appendRow(row); });
+    return _json({status: 'appended', rows_added: req.rows.length});
+  }
+
+  // --- Drive ---
+
+  function _driveList(req) {
+    var iter = req.query ? DriveApp.searchFiles(req.query) : DriveApp.getFiles();
+    var files = [], count = req.count || 10;
+    while (iter.hasNext() && files.length < count) {
+      var f = iter.next();
+      files.push({
+        id: f.getId(), name: f.getName(), type: f.getMimeType(),
+        size: f.getSize(), url: f.getUrl(), updated: f.getLastUpdated().toISOString()
+      });
+    }
+    return _json({files: files, count: files.length});
+  }
+
+  function _driveCreate(req) {
+    if (!req.name) return _json({error: 'missing name'});
+    var type = req.type || 'document';
+    var file;
+    if (type === 'spreadsheet') {
+      file = SpreadsheetApp.create(req.name);
+    } else if (type === 'document') {
+      file = DocumentApp.create(req.name);
+    } else {
+      file = DriveApp.createFile(req.name, req.content || '', req.mime || 'text/plain');
+      return _json({id: file.getId(), name: file.getName(), url: file.getUrl()});
+    }
+    return _json({id: file.getId(), name: req.name, url: file.getUrl()});
+  }
+
+  // --- Calendar ---
+
+  function _calendarList(req) {
+    var now = new Date(), end = new Date(now.getTime() + (req.days || 7) * 86400000);
+    var events = CalendarApp.getDefaultCalendar().getEvents(now, end).map(function(ev) {
+      return {
+        title: ev.getTitle(), start: ev.getStartTime().toISOString(),
+        end: ev.getEndTime().toISOString(), location: ev.getLocation()
+      };
+    });
+    return _json({events: events, count: events.length});
+  }
+
+  // --- Docs ---
+
+  function _docsCreate(req) {
+    if (!req.title) return _json({error: 'missing title'});
+    var doc = DocumentApp.create(req.title);
+    if (req.body) doc.getBody().appendParagraph(req.body);
+    return _json({id: doc.getId(), title: req.title, url: doc.getUrl()});
+  }
+
+  // --- Contacts ---
+
+  function _contactsList(req) {
+    var contacts = ContactsApp.getContacts();
+    var count = req.count || 20;
+    var results = contacts.slice(0, count).map(function(c) {
+      var emails = c.getEmails();
+      return {name: c.getFullName(), email: emails.length > 0 ? emails[0].getAddress() : null};
+    });
+    return _json({contacts: results, count: results.length});
+  }
+
+  // --- Google Tasks ---
+
+  function _tasksList(req) {
+    try {
+      var taskLists = Tasks.Tasklists.list();
+      var results = taskLists.items.map(function(list) {
+        var tasks = Tasks.Tasks.list(list.id);
+        return {
+          list: list.title,
+          tasks: (tasks.items || []).map(function(t) {
+            return {title: t.title, status: t.status, due: t.due || null};
+          })
+        };
+      });
+      return _json({taskLists: results});
+    } catch (e) {
+      return _json({error: 'Tasks API not enabled. Add via Services > Tasks API.', detail: e.message});
+    }
+  }
+
+  // --- Translate ---
+
+  function _translate(req) {
+    if (!req.text) return _json({error: 'missing text'});
+    var result = LanguageApp.translate(req.text, req.from || 'auto', req.to || 'en');
+    return _json({translated: result, from: req.from || 'auto', to: req.to || 'en'});
+  }
+
+  // --- HTTP Proxy ---
+
+  function _fetch(req) {
+    if (!req.url) return _json({error: 'missing url'});
+    var opts = {muteHttpExceptions: true, method: req.method || 'get'};
+    if (req.headers) opts.headers = req.headers;
+    if (req.payload) opts.payload = req.payload;
+    if (req.contentType) opts.contentType = req.contentType;
+    var resp = UrlFetchApp.fetch(req.url, opts);
+    var body = resp.getContentText();
+    try { body = JSON.parse(body); } catch (e) {}
+    return _json({status: resp.getResponseCode(), headers: resp.getHeaders(), body: body});
+  }
+
+  // --- Token ---
+
+  function _tokenGet(req) {
+    return _json({
+      access_token: ScriptApp.getOAuthToken(),
+      expires_in: 3600,
+      note: 'Scopes depend on which services have been activated via activateScopes().'
+    });
+  }
+
+  // --- Helpers ---
+
+  function _json(obj) {
+    return ContentService.createTextOutput(JSON.stringify(obj))
+      .setMimeType(ContentService.MimeType.JSON);
+  }
+
+  // --- Setup Functions (run from the Apps Script editor) ---
+
+  function initKey() {
+    var key = Utilities.getUuid();
+    PropertiesService.getScriptProperties().setProperty('BRIDGE_KEY', key);
+    Logger.log('Your bridge key: ' + key);
+    Logger.log('Store this securely. Use it in the "key" field of every POST request.');
+  }
+
+  function getKey() {
+    var key = PropertiesService.getScriptProperties().getProperty('BRIDGE_KEY');
+    Logger.log(key ? 'Current key: ' + key : 'No key set. Run Bridge.initKey() first.');
+  }
+
+  function activateScopes() {
+    var results = [];
+    try { GmailApp.search('subject:test', 0, 1); results.push('Gmail: OK'); } catch (e) { results.push('Gmail: ' + e.message); }
+    try { DriveApp.getFiles(); results.push('Drive: OK'); } catch (e) { results.push('Drive: ' + e.message); }
+    try { var s = SpreadsheetApp.create('_scope_test'); DriveApp.getFileById(s.getId()).setTrashed(true); results.push('Sheets: OK'); } catch (e) { results.push('Sheets: ' + e.message); }
+    try { var d = DocumentApp.create('_scope_test'); DriveApp.getFileById(d.getId()).setTrashed(true); results.push('Docs: OK'); } catch (e) { results.push('Docs: ' + e.message); }
+    try { CalendarApp.getDefaultCalendar(); results.push('Calendar: OK'); } catch (e) { results.push('Calendar: ' + e.message); }
+    try { ContactsApp.getContacts(); results.push('Contacts: OK'); } catch (e) { results.push('Contacts: ' + e.message); }
+    try { UrlFetchApp.fetch('https://httpbin.org/get', {muteHttpExceptions: true}); results.push('UrlFetch: OK'); } catch (e) { results.push('UrlFetch: ' + e.message); }
+    try { LanguageApp.translate('hello', 'en', 'es'); results.push('Translate: OK'); } catch (e) { results.push('Translate: ' + e.message); }
+    try { results.push('Mail quota: ' + MailApp.getRemainingDailyQuota() + ' emails/day'); } catch (e) { results.push('MailApp: ' + e.message); }
+    try { Tasks.Tasklists.list(); results.push('Tasks: OK'); } catch (e) { results.push('Tasks: enable via Services > Tasks API'); }
+    results.push('OAuth token: ' + (ScriptApp.getOAuthToken() ? 'OK' : 'NONE'));
+    Logger.log('=== Scope Activation ===\n' + results.join('\n'));
+    return results;
+  }
+
+  // Public API
+  return {
+    doGet: doGet,
+    doPost: doPost,
+    initKey: initKey,
+    getKey: getKey,
+    activateScopes: activateScopes
+  };
+
+})();
+
+// Top-level entry points required by Google Apps Script Web App
+function doGet(e)  { return Bridge.doGet(e); }
+function doPost(e) { return Bridge.doPost(e); }

--- a/bridge/Code.js
+++ b/bridge/Code.js
@@ -72,6 +72,22 @@ var Bridge = (function() {
     'translate':       _translate,
     'fetch':           _fetch,
     'token.get':       _tokenGet,
+    'gmail.get':           _gmailGet,
+    'gmail.read':          _gmailRead,
+    'gmail.archive':       _gmailArchive,
+    'gmail.reply':         _gmailReply,
+    'gmail.label':         _gmailLabel,
+    'gmail.attachments':   _gmailAttachments,
+    'sheets.create':       _sheetsCreate,
+    'sheets.update':       _sheetsUpdate,
+    'drive.upload':        _driveUpload,
+    'drive.download':      _driveDownload,
+    'calendar.get':        _calendarGet,
+    'calendar.create':     _calendarCreate,
+    'calendar.delete':     _calendarDelete,
+    'calendar.calendars':  _calendarCalendars,
+    'tasks.create':        _tasksCreate,
+    'tasks.update':        _tasksUpdate,
   };
 
   // --- Info ---
@@ -95,6 +111,19 @@ var Bridge = (function() {
     if (req.bcc) opts.bcc = req.bcc;
     if (req.html) opts.htmlBody = req.body;
     if (req.replyTo) opts.replyTo = req.replyTo;
+    if (req.inlineImages) {
+      var imgs = {};
+      for (var k in req.inlineImages) {
+        var img = req.inlineImages[k];
+        imgs[k] = Utilities.newBlob(Utilities.base64Decode(img.data), img.mimeType, k);
+      }
+      opts.inlineImages = imgs;
+    }
+    if (req.attachments) {
+      opts.attachments = req.attachments.map(function(a) {
+        return Utilities.newBlob(Utilities.base64Decode(a.data), a.mimeType, a.name);
+      });
+    }
     GmailApp.sendEmail(req.to, req.subject || '(no subject)', req.body || '', opts);
     return _json({status: 'sent', to: req.to, subject: req.subject});
   }
@@ -168,7 +197,8 @@ var Bridge = (function() {
 
   function _calendarList(req) {
     var now = new Date(), end = new Date(now.getTime() + (req.days || 7) * 86400000);
-    var events = CalendarApp.getDefaultCalendar().getEvents(now, end).map(function(ev) {
+    var cal = req.calendarId ? CalendarApp.getCalendarById(req.calendarId) : CalendarApp.getDefaultCalendar();
+    var events = cal.getEvents(now, end).map(function(ev) {
       return {
         title: ev.getTitle(), start: ev.getStartTime().toISOString(),
         end: ev.getEndTime().toISOString(), location: ev.getLocation()
@@ -254,6 +284,229 @@ var Bridge = (function() {
       expires_in: 3600,
       note: 'Scopes depend on which services have been activated via activateScopes().'
     });
+  }
+
+  // --- Gmail (extended) ---
+
+  function _gmailGet(req) {
+    if (!req.thread_id) return _json({error: 'missing thread_id'});
+    var thread = GmailApp.getThreadById(req.thread_id);
+    if (!thread) return _json({error: 'thread not found'});
+    var msgs = thread.getMessages().map(function(m) {
+      return {
+        id: m.getId(), subject: m.getSubject(), from: m.getFrom(),
+        to: m.getTo(), cc: m.getCc(), date: m.getDate().toISOString(),
+        plain: m.getPlainBody().substring(0, 300), html: m.getBody(),
+        attachments: m.getAttachments().map(function(a) {
+          return {name: a.getName(), type: a.getContentType(), size: a.getSize()};
+        }),
+        starred: m.isStarred()
+      };
+    });
+    return _json({thread_id: req.thread_id, messages: msgs, count: msgs.length});
+  }
+
+  function _gmailRead(req) {
+    if (!req.thread_id) return _json({error: 'missing thread_id'});
+    GmailApp.getThreadById(req.thread_id).markRead();
+    return _json({status: 'marked_read', thread_id: req.thread_id});
+  }
+
+  function _gmailArchive(req) {
+    if (!req.thread_id) return _json({error: 'missing thread_id'});
+    var thread = GmailApp.getThreadById(req.thread_id);
+    thread.markRead();
+    thread.moveToArchive();
+    return _json({status: 'archived', thread_id: req.thread_id});
+  }
+
+  function _gmailReply(req) {
+    if (!req.thread_id) return _json({error: 'missing thread_id'});
+    if (!req.body) return _json({error: 'missing body'});
+    var me = Session.getActiveUser().getEmail();
+    var msgs = GmailApp.getThreadById(req.thread_id).getMessages();
+    var msg = msgs[msgs.length - 1];
+    for (var i = msgs.length - 1; i >= 0; i--) {
+      if (msgs[i].getFrom().indexOf(me) === -1) { msg = msgs[i]; break; }
+    }
+    var opts = {};
+    if (req.html) opts.htmlBody = req.body;
+    if (req.cc) opts.cc = req.cc;
+    if (req.inlineImages) {
+      var imgs = {};
+      for (var k in req.inlineImages) {
+        var img = req.inlineImages[k];
+        imgs[k] = Utilities.newBlob(Utilities.base64Decode(img.data), img.mimeType, k);
+      }
+      opts.inlineImages = imgs;
+    }
+    msg.reply(req.body, opts);
+    return _json({status: 'replied', thread_id: req.thread_id, replied_to: msg.getId()});
+  }
+
+  function _gmailLabel(req) {
+    if (!req.thread_id) return _json({error: 'missing thread_id'});
+    var thread = GmailApp.getThreadById(req.thread_id);
+    if (req.add) {
+      var label = GmailApp.getUserLabelByName(req.add) || GmailApp.createLabel(req.add);
+      thread.addLabel(label);
+    }
+    if (req.remove) {
+      var rlabel = GmailApp.getUserLabelByName(req.remove);
+      if (rlabel) thread.removeLabel(rlabel);
+    }
+    return _json({status: 'labeled', thread_id: req.thread_id, add: req.add || null, remove: req.remove || null});
+  }
+
+  function _gmailAttachments(req) {
+    var msgs;
+    if (req.message_id) {
+      msgs = [GmailApp.getMessageById(req.message_id)];
+    } else if (req.thread_id) {
+      msgs = GmailApp.getThreadById(req.thread_id).getMessages();
+    } else {
+      return _json({error: 'missing message_id or thread_id'});
+    }
+    var results = [];
+    msgs.forEach(function(m) {
+      m.getAttachments().forEach(function(a) {
+        var item = {filename: a.getName(), mimeType: a.getContentType(), size: a.getSize(), message_id: m.getId()};
+        if (a.getSize() <= 1048576) {
+          item.data = Utilities.base64Encode(a.getBytes());
+        } else {
+          item.truncated = true;
+        }
+        if (req.save_to_drive) {
+          var file = DriveApp.createFile(a);
+          item.drive_id = file.getId();
+          item.drive_url = file.getUrl();
+        }
+        results.push(item);
+      });
+    });
+    return _json({attachments: results, count: results.length});
+  }
+
+  // --- Sheets (extended) ---
+
+  function _sheetsCreate(req) {
+    if (!req.name) return _json({error: 'missing name'});
+    var ss = SpreadsheetApp.create(req.name);
+    if (req.headers) ss.getActiveSheet().appendRow(req.headers);
+    return _json({id: ss.getId(), name: req.name, url: ss.getUrl()});
+  }
+
+  function _sheetsUpdate(req) {
+    if (!req.spreadsheet_id) return _json({error: 'missing spreadsheet_id'});
+    if (!req.range) return _json({error: 'missing range'});
+    if (!req.values) return _json({error: 'missing values'});
+    SpreadsheetApp.openById(req.spreadsheet_id).getRange(req.range).setValues(req.values);
+    return _json({status: 'updated', range: req.range});
+  }
+
+  // --- Drive (extended) ---
+
+  function _driveUpload(req) {
+    if (!req.name) return _json({error: 'missing name'});
+    if (!req.data_base64) return _json({error: 'missing data_base64'});
+    var blob = Utilities.newBlob(Utilities.base64Decode(req.data_base64), req.mime || 'application/octet-stream', req.name);
+    var file;
+    if (req.folder_id) {
+      file = DriveApp.getFolderById(req.folder_id).createFile(blob);
+    } else {
+      file = DriveApp.createFile(blob);
+    }
+    return _json({id: file.getId(), name: file.getName(), url: file.getUrl(), size: file.getSize()});
+  }
+
+  function _driveDownload(req) {
+    if (!req.id) return _json({error: 'missing id'});
+    var file = DriveApp.getFileById(req.id);
+    var blob = file.getBlob();
+    return _json({
+      id: file.getId(), name: file.getName(), mimeType: blob.getContentType(),
+      size: file.getSize(), data: Utilities.base64Encode(blob.getBytes())
+    });
+  }
+
+  // --- Calendar (extended) ---
+
+  function _calendarGet(req) {
+    if (!req.event_id) return _json({error: 'missing event_id'});
+    var cal = req.calendarId ? CalendarApp.getCalendarById(req.calendarId) : CalendarApp.getDefaultCalendar();
+    var ev = cal.getEventById(req.event_id);
+    if (!ev) return _json({error: 'event not found'});
+    return _json({
+      id: ev.getId(), title: ev.getTitle(),
+      start: ev.getStartTime().toISOString(), end: ev.getEndTime().toISOString(),
+      description: ev.getDescription(), location: ev.getLocation(),
+      attendees: ev.getGuestList().map(function(g) { return g.getEmail(); }),
+      allDay: ev.isAllDayEvent()
+    });
+  }
+
+  function _calendarCreate(req) {
+    if (!req.title) return _json({error: 'missing title'});
+    if (!req.start || !req.end) return _json({error: 'missing start or end'});
+    var cal = req.calendarId ? CalendarApp.getCalendarById(req.calendarId) : CalendarApp.getDefaultCalendar();
+    var opts = {};
+    if (req.description) opts.description = req.description;
+    if (req.location) opts.location = req.location;
+    if (req.guests) opts.guests = req.guests;
+    var ev = cal.createEvent(req.title, new Date(req.start), new Date(req.end), opts);
+    return _json({status: 'created', id: ev.getId(), title: req.title, start: req.start, end: req.end});
+  }
+
+  function _calendarDelete(req) {
+    if (!req.event_id) return _json({error: 'missing event_id'});
+    var cal = req.calendarId ? CalendarApp.getCalendarById(req.calendarId) : CalendarApp.getDefaultCalendar();
+    var ev = cal.getEventById(req.event_id);
+    if (!ev) return _json({error: 'event not found'});
+    ev.deleteEvent();
+    return _json({status: 'deleted', event_id: req.event_id});
+  }
+
+  function _calendarCalendars(req) {
+    var cals = CalendarApp.getAllCalendars().map(function(c) {
+      return {
+        id: c.getId(), name: c.getName(), description: c.getDescription(),
+        selected: c.isSelected(), owned: c.isOwnedByMe()
+      };
+    });
+    return _json({calendars: cals, count: cals.length});
+  }
+
+  // --- Tasks (extended) ---
+
+  function _tasksCreate(req) {
+    if (!req.title) return _json({error: 'missing title'});
+    try {
+      var listId = req.list_id || Tasks.Tasklists.list().items[0].id;
+      var resource = {title: req.title};
+      if (req.notes) resource.notes = req.notes;
+      if (req.due) resource.due = req.due;
+      if (req.status) resource.status = req.status;
+      var task = Tasks.Tasks.insert(resource, listId);
+      return _json({id: task.id, title: task.title, status: task.status, listId: listId});
+    } catch (e) {
+      return _json({error: 'Tasks API error', detail: e.message});
+    }
+  }
+
+  function _tasksUpdate(req) {
+    if (!req.task_id) return _json({error: 'missing task_id'});
+    try {
+      var listId = req.list_id || Tasks.Tasklists.list().items[0].id;
+      var resource = {};
+      if (req.title) resource.title = req.title;
+      if (req.notes !== undefined) resource.notes = req.notes;
+      if (req.status) resource.status = req.status;
+      if (req.due) resource.due = req.due;
+      var task = Tasks.Tasks.patch(resource, listId, req.task_id);
+      return _json({id: task.id, title: task.title, status: task.status});
+    } catch (e) {
+      return _json({error: 'Tasks API error', detail: e.message});
+    }
   }
 
   // --- Helpers ---

--- a/bridge/Code.js
+++ b/bridge/Code.js
@@ -19,8 +19,13 @@
  * Security:
  *   Every POST request must include a valid key. Generate one with Bridge.initKey().
  *   Keys are stored in Script Properties (not in source code). Rotate your key
- *   regularly — this is a shared-secret scheme, not OAuth. Anyone with the key
+ *   as needed — this is a shared-secret scheme, not OAuth. Anyone with the key
  *   and the deployment URL has access to whichever Google services are enabled.
+ *
+ *   The "fetch" and "token.get" actions are disabled by default because they
+ *   expose powerful capabilities (arbitrary HTTP requests and raw OAuth tokens).
+ *   Enable them explicitly by running Bridge.enableFetch() or Bridge.enableTokenGet()
+ *   from the Apps Script editor.
  */
 
 var Bridge = (function() {
@@ -221,9 +226,12 @@ var Bridge = (function() {
     return _json({translated: result, from: req.from || 'auto', to: req.to || 'en'});
   }
 
-  // --- HTTP Proxy ---
+  // --- HTTP Proxy (disabled by default — run Bridge.enableFetch() to enable) ---
 
   function _fetch(req) {
+    if (!_isEnabled('FETCH_ENABLED')) {
+      return _json({error: 'fetch is disabled. Run Bridge.enableFetch() from the Apps Script editor to enable it.'});
+    }
     if (!req.url) return _json({error: 'missing url'});
     var opts = {muteHttpExceptions: true, method: req.method || 'get'};
     if (req.headers) opts.headers = req.headers;
@@ -235,9 +243,12 @@ var Bridge = (function() {
     return _json({status: resp.getResponseCode(), headers: resp.getHeaders(), body: body});
   }
 
-  // --- Token ---
+  // --- Token (disabled by default — run Bridge.enableTokenGet() to enable) ---
 
   function _tokenGet(req) {
+    if (!_isEnabled('TOKEN_GET_ENABLED')) {
+      return _json({error: 'token.get is disabled. Run Bridge.enableTokenGet() from the Apps Script editor to enable it.'});
+    }
     return _json({
       access_token: ScriptApp.getOAuthToken(),
       expires_in: 3600,
@@ -246,6 +257,10 @@ var Bridge = (function() {
   }
 
   // --- Helpers ---
+
+  function _isEnabled(property) {
+    return PropertiesService.getScriptProperties().getProperty(property) === 'true';
+  }
 
   function _json(obj) {
     return ContentService.createTextOutput(JSON.stringify(obj))
@@ -283,13 +298,39 @@ var Bridge = (function() {
     return results;
   }
 
+  // --- Enable/Disable Sensitive Actions (run from the Apps Script editor) ---
+
+  function enableFetch() {
+    PropertiesService.getScriptProperties().setProperty('FETCH_ENABLED', 'true');
+    Logger.log('fetch action ENABLED.');
+  }
+
+  function disableFetch() {
+    PropertiesService.getScriptProperties().deleteProperty('FETCH_ENABLED');
+    Logger.log('fetch action DISABLED.');
+  }
+
+  function enableTokenGet() {
+    PropertiesService.getScriptProperties().setProperty('TOKEN_GET_ENABLED', 'true');
+    Logger.log('token.get action ENABLED.');
+  }
+
+  function disableTokenGet() {
+    PropertiesService.getScriptProperties().deleteProperty('TOKEN_GET_ENABLED');
+    Logger.log('token.get action DISABLED.');
+  }
+
   // Public API
   return {
     doGet: doGet,
     doPost: doPost,
     initKey: initKey,
     getKey: getKey,
-    activateScopes: activateScopes
+    activateScopes: activateScopes,
+    enableFetch: enableFetch,
+    disableFetch: disableFetch,
+    enableTokenGet: enableTokenGet,
+    disableTokenGet: disableTokenGet
   };
 
 })();

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -71,16 +71,32 @@ curl -s -L -X POST 'YOUR_DEPLOYMENT_URL' \
 | Action | Description | Required Fields |
 |--------|-------------|-----------------|
 | `info` | Health check, list actions | — |
-| `gmail.send` | Send email | `to` (+ `subject`, `body`, `cc`, `bcc`, `html`, `replyTo`) |
+| `gmail.send` | Send email | `to` (+ `subject`, `body`, `cc`, `bcc`, `html`, `replyTo`, `inlineImages`, `attachments`) |
 | `gmail.check` | Search inbox | `query` (default: `is:unread`), `count` |
+| `gmail.get` | Get full thread | `thread_id` |
+| `gmail.read` | Mark thread read | `thread_id` |
+| `gmail.archive` | Archive thread | `thread_id` |
+| `gmail.reply` | Reply to thread | `thread_id`, `body` (+ `html`, `cc`, `inlineImages`) |
+| `gmail.label` | Add/remove label | `thread_id`, `add`, `remove` |
+| `gmail.attachments` | Get attachments | `message_id` or `thread_id` (+ `save_to_drive`) |
 | `sheets.read` | Read spreadsheet | `spreadsheet_id`, `range` |
 | `sheets.append` | Append rows | `spreadsheet_id`, `rows`, `sheet` |
+| `sheets.create` | Create spreadsheet | `name` (+ `headers`) |
+| `sheets.update` | Update cell range | `spreadsheet_id`, `range`, `values` |
 | `drive.list` | List/search files | `query`, `count` |
 | `drive.create` | Create file | `name`, `type`, `content`, `mime` |
-| `calendar.list` | Upcoming events | `days` (default: 7) |
+| `drive.upload` | Upload binary file | `name`, `data_base64` (+ `mime`, `folder_id`) |
+| `drive.download` | Download file as base64 | `id` |
+| `calendar.list` | Upcoming events | `days` (default: 7), `calendarId` |
+| `calendar.get` | Get single event | `event_id` (+ `calendarId`) |
+| `calendar.create` | Create event | `title`, `start`, `end` (+ `description`, `location`, `guests`, `calendarId`) |
+| `calendar.delete` | Delete event | `event_id` (+ `calendarId`) |
+| `calendar.calendars` | List all calendars | — |
 | `docs.create` | Create Google Doc | `title`, `body` |
 | `contacts.list` | List contacts | `count` |
 | `tasks.list` | List Google Tasks | — (requires Tasks API enabled) |
+| `tasks.create` | Create a task | `title` (+ `notes`, `due`, `status`, `list_id`) |
+| `tasks.update` | Update a task | `task_id` (+ `title`, `notes`, `status`, `due`, `list_id`) |
 | `translate` | Translate text | `text`, `from`, `to` |
 | `fetch` | HTTP proxy (disabled by default) | `url`, `method`, `headers`, `payload`, `contentType` |
 | `token.get` | Get OAuth token (disabled by default) | — |

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -1,0 +1,123 @@
+# GAS Bridge
+
+Turn a Google Apps Script project into a key-authenticated JSON API.
+
+GAS Bridge deploys as a [Web App](https://developers.google.com/apps-script/guides/web) and exposes Google Workspace services — Gmail, Drive, Sheets, Calendar, Docs, Contacts, Translate, and Tasks — through simple HTTP POST requests. Any language or tool that can send JSON over HTTPS can use it.
+
+## Quick Start
+
+### 1. Create the Script
+
+1. Go to [script.google.com](https://script.google.com) and create a new project.
+2. Replace the contents of `Code.gs` with [`Code.js`](Code.js) from this folder.
+3. Copy `appsscript.json` into the project (Editor > Project Settings > Show manifest).
+
+### 2. Generate a Key
+
+In the Apps Script editor:
+
+1. Select `Bridge.initKey` from the function dropdown.
+2. Click **Run** (authorize when prompted).
+3. Open **Execution Log** — your key is printed there.
+
+Store this key securely. It authenticates every request to your bridge.
+
+### 3. Activate Services
+
+Run `Bridge.activateScopes` to trigger authorization prompts for each Google service. This ensures the OAuth token covers all the APIs you want to use. You only need to do this once (or again if you add new services).
+
+### 4. Deploy
+
+1. **Deploy** > **New Deployment**
+2. Type: **Web App**
+3. Execute as: **Me**
+4. Who has access: **Anyone**
+5. Click **Deploy** and copy the URL.
+
+### 5. Use It
+
+```bash
+# Health check
+curl -s -L -X POST 'YOUR_DEPLOYMENT_URL' \
+  -H 'Content-Type: application/json' \
+  -d '{"action": "info", "key": "YOUR_KEY"}' | python3 -m json.tool
+
+# Send an email
+curl -s -L -X POST 'YOUR_DEPLOYMENT_URL' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "action": "gmail.send",
+    "key": "YOUR_KEY",
+    "to": "someone@example.com",
+    "subject": "Hello from GAS Bridge",
+    "body": "Sent via a simple POST request."
+  }'
+
+# Read a spreadsheet
+curl -s -L -X POST 'YOUR_DEPLOYMENT_URL' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "action": "sheets.read",
+    "key": "YOUR_KEY",
+    "spreadsheet_id": "YOUR_SHEET_ID",
+    "range": "Sheet1!A1:C10"
+  }'
+```
+
+> **Note:** Use `-L` with curl — Google Apps Script redirects on first request.
+
+## Available Actions
+
+| Action | Description | Required Fields |
+|--------|-------------|-----------------|
+| `info` | Health check, list actions | — |
+| `gmail.send` | Send email | `to` (+ `subject`, `body`, `cc`, `bcc`, `html`, `replyTo`) |
+| `gmail.check` | Search inbox | `query` (default: `is:unread`), `count` |
+| `sheets.read` | Read spreadsheet | `spreadsheet_id`, `range` |
+| `sheets.append` | Append rows | `spreadsheet_id`, `rows`, `sheet` |
+| `drive.list` | List/search files | `query`, `count` |
+| `drive.create` | Create file | `name`, `type`, `content`, `mime` |
+| `calendar.list` | Upcoming events | `days` (default: 7) |
+| `docs.create` | Create Google Doc | `title`, `body` |
+| `contacts.list` | List contacts | `count` |
+| `tasks.list` | List Google Tasks | — (requires Tasks API enabled) |
+| `translate` | Translate text | `text`, `from`, `to` |
+| `fetch` | HTTP proxy | `url`, `method`, `headers`, `payload`, `contentType` |
+| `token.get` | Get OAuth token | — |
+
+Every request is a JSON POST with at minimum `{"action": "...", "key": "..."}`.
+
+Every response is JSON with either the result or `{"error": "..."}`.
+
+## Security
+
+GAS Bridge uses a **shared secret key** stored in Script Properties (never in source code). This is simple and effective for personal use and trusted integrations, but it is not OAuth — anyone with the key and the deployment URL has full access to the enabled services.
+
+**Recommendations:**
+
+- **Rotate your key regularly.** Run `Bridge.initKey()` to generate a new one. Update all clients that use the old key.
+- **Limit scope.** Only run `activateScopes()` for services you actually need. Remove actions from the `HANDLERS` map if you want to disable them.
+- **Keep the deployment URL private.** The URL plus the key is all that's needed to access your Google account's services.
+- **Monitor usage.** Check the Apps Script dashboard (Executions tab) for unexpected activity.
+
+## Updating
+
+After editing `Code.gs`:
+
+1. **Deploy** > **Manage Deployments** > **Edit** (pencil icon)
+2. Version: **New Version**
+3. Click **Deploy**
+
+The URL stays the same — clients don't need to change anything.
+
+## How It Works
+
+The bridge is a single Apps Script file that:
+
+1. **`doGet`** returns a simple health-check text response.
+2. **`doPost`** parses the JSON body, validates the key, and routes the `action` to the matching handler function.
+3. Each handler wraps a Google Apps Script API (GmailApp, SpreadsheetApp, DriveApp, etc.) and returns a JSON response.
+
+The `fetch` action is an HTTP proxy — it lets you make outbound HTTP requests from Google's servers, which is useful when you need a clean IP or want to call APIs from environments with network restrictions.
+
+The `token.get` action returns a live OAuth access token that inherits the script's authorized scopes. This is useful for calling Google APIs directly (e.g., from a local script) without managing your own OAuth flow.

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -82,8 +82,8 @@ curl -s -L -X POST 'YOUR_DEPLOYMENT_URL' \
 | `contacts.list` | List contacts | `count` |
 | `tasks.list` | List Google Tasks | — (requires Tasks API enabled) |
 | `translate` | Translate text | `text`, `from`, `to` |
-| `fetch` | HTTP proxy | `url`, `method`, `headers`, `payload`, `contentType` |
-| `token.get` | Get OAuth token | — |
+| `fetch` | HTTP proxy (disabled by default) | `url`, `method`, `headers`, `payload`, `contentType` |
+| `token.get` | Get OAuth token (disabled by default) | — |
 
 Every request is a JSON POST with at minimum `{"action": "...", "key": "..."}`.
 
@@ -95,7 +95,7 @@ GAS Bridge uses a **shared secret key** stored in Script Properties (never in so
 
 **Recommendations:**
 
-- **Rotate your key regularly.** Run `Bridge.initKey()` to generate a new one. Update all clients that use the old key.
+- **Rotate your key as needed.** Run `Bridge.initKey()` to generate a new one. Update all clients that use the old key.
 - **Limit scope.** Only run `activateScopes()` for services you actually need. Remove actions from the `HANDLERS` map if you want to disable them.
 - **Keep the deployment URL private.** The URL plus the key is all that's needed to access your Google account's services.
 - **Monitor usage.** Check the Apps Script dashboard (Executions tab) for unexpected activity.
@@ -118,6 +118,6 @@ The bridge is a single Apps Script file that:
 2. **`doPost`** parses the JSON body, validates the key, and routes the `action` to the matching handler function.
 3. Each handler wraps a Google Apps Script API (GmailApp, SpreadsheetApp, DriveApp, etc.) and returns a JSON response.
 
-The `fetch` action is an HTTP proxy — it lets you make outbound HTTP requests from Google's servers, which is useful when you need a clean IP or want to call APIs from environments with network restrictions.
+The `fetch` action is an HTTP proxy — it lets you make outbound HTTP requests from Google's servers, which is useful when you need a clean IP or want to call APIs from environments with network restrictions. **It is disabled by default.** Run `Bridge.enableFetch()` from the Apps Script editor to enable it, or `Bridge.disableFetch()` to disable it again.
 
-The `token.get` action returns a live OAuth access token that inherits the script's authorized scopes. This is useful for calling Google APIs directly (e.g., from a local script) without managing your own OAuth flow.
+The `token.get` action returns a live OAuth access token that inherits the script's authorized scopes. This is useful for calling Google APIs directly (e.g., from a local script) without managing your own OAuth flow. **It is disabled by default.** Run `Bridge.enableTokenGet()` to enable it, or `Bridge.disableTokenGet()` to disable it again.

--- a/bridge/appsscript.json
+++ b/bridge/appsscript.json
@@ -1,0 +1,18 @@
+{
+  "timeZone": "America/Los_Angeles",
+  "dependencies": {
+    "enabledAdvancedServices": [
+      {
+        "userSymbol": "Tasks",
+        "version": "v1",
+        "serviceId": "tasks"
+      }
+    ]
+  },
+  "webapp": {
+    "executeAs": "USER_DEPLOYING",
+    "access": "ANYONE"
+  },
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8"
+}


### PR DESCRIPTION
## Summary

Closes the gap between the generic GAS Bridge (14 actions) and the full knobert version (38 actions). Adds the 16 most valuable missing actions while keeping the generic single-key auth model (no RBAC).

**New actions (16):**

| Action | Description |
|--------|-------------|
| `gmail.get` | Get full thread with all messages, HTML bodies, attachment metadata |
| `gmail.read` | Mark thread as read |
| `gmail.archive` | Mark read + move to archive |
| `gmail.reply` | Reply to last non-self message (preserves threading) |
| `gmail.label` | Add/remove labels (auto-creates if needed) |
| `gmail.attachments` | Get attachments with base64 data (≤1MB) or save to Drive |
| `sheets.create` | Create spreadsheet with optional headers |
| `sheets.update` | Write values to a specific range |
| `drive.upload` | Upload base64-encoded binary to Drive |
| `drive.download` | Download file as base64 |
| `calendar.get` | Get full event details with attendees |
| `calendar.create` | Create event with description/location/guests |
| `calendar.delete` | Delete event |
| `calendar.calendars` | List all calendars |
| `tasks.create` | Create task with notes/due/status |
| `tasks.update` | Update task fields |

**Enhanced existing actions (2):**
- `gmail.send`: Added `inlineImages` (CID protocol) and `attachments` support
- `calendar.list`: Added `calendarId` parameter for non-default calendars

**What's NOT included (remaining delta for future PRs):**
- RBAC (4-role system) — the generic version stays single-key
- `gmail.draft.*` (create/list/get/send/delete)
- `contacts.*` CRUD (requires People API Advanced Service)
- `chat.send/read` (Sheet-backed messaging)
- `gemini.ask` (AI integration)
- `config.get/set/self` (Script Properties management)
- `driveImages` in gmail.send (server-side Drive image inlining)

## Test plan
- [ ] Deploy to a test GAS project via `clasp push && clasp deploy`
- [ ] Verify `info` returns 30 actions
- [ ] Test `gmail.send` with `inlineImages` parameter
- [ ] Test `drive.upload` + `drive.download` round-trip
- [ ] Test `calendar.create` + `calendar.get`
- [ ] Test `tasks.create` (requires Tasks Advanced Service enabled)
- [ ] Verify `fetch` and `token.get` remain disabled by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)