### PR TITLE
Name resolution for sheets and drive actions

### DIFF
--- a/bridge/Code.js
+++ b/bridge/Code.js
@@ -237,7 +237,8 @@ var Bridge = (function() {
   }
 
   function _driveDownload(req) {
-    if (!req.id) return _json({error: 'missing id'});
+    if (!req.id && req.name) req.id = _resolveByName(req.name);
+    if (!req.id) return _json({error: 'missing id or name'});
     var file = DriveApp.getFileById(req.id);
     var blob = file.getBlob();
     return _json({
@@ -554,7 +555,8 @@ var Bridge = (function() {
   // =========================================================================
 
   function _sheetsAppend(req) {
-    if (!req.spreadsheet_id) return _json({error: 'missing spreadsheet_id'});
+    if (!req.spreadsheet_id && req.name) req.spreadsheet_id = _resolveByName(req.name, 'application/vnd.google-apps.spreadsheet');
+    if (!req.spreadsheet_id) return _json({error: 'missing spreadsheet_id or name'});
     if (!req.rows || !req.rows.length) return _json({error: 'no rows'});
     var sheet = SpreadsheetApp.openById(req.spreadsheet_id).getSheetByName(req.sheet || 'Sheet1');
     if (!sheet) return _json({error: 'sheet not found'});
@@ -570,7 +572,8 @@ var Bridge = (function() {
   }
 
   function _sheetsRead(req) {
-    if (!req.spreadsheet_id) return _json({error: 'missing spreadsheet_id'});
+    if (!req.spreadsheet_id && req.name) req.spreadsheet_id = _resolveByName(req.name, 'application/vnd.google-apps.spreadsheet');
+    if (!req.spreadsheet_id) return _json({error: 'missing spreadsheet_id or name'});
     var data = SpreadsheetApp.openById(req.spreadsheet_id)
       .getRange(req.range || 'Sheet1!A1:Z100').getValues();
     while (data.length > 0 && data[data.length - 1].every(function(c) { return c === ''; })) data.pop();
@@ -578,7 +581,8 @@ var Bridge = (function() {
   }
 
   function _sheetsUpdate(req) {
-    if (!req.spreadsheet_id) return _json({error: 'missing spreadsheet_id'});
+    if (!req.spreadsheet_id && req.name) req.spreadsheet_id = _resolveByName(req.name, 'application/vnd.google-apps.spreadsheet');
+    if (!req.spreadsheet_id) return _json({error: 'missing spreadsheet_id or name'});
     if (!req.range) return _json({error: 'missing range'});
     if (!req.values) return _json({error: 'missing values (2D array)'});
     SpreadsheetApp.openById(req.spreadsheet_id).getRange(req.range).setValues(req.values);
@@ -732,6 +736,19 @@ var Bridge = (function() {
   // Convert 4-byte emoji (astral plane, U+10000+) to HTML numeric entities.
   // GAS's JS runtime uses UCS-2 and mangles surrogate pairs. Email clients
   // render &#x1F419; as the octopus emoji correctly.
+  function _resolveByName(name, mimeType) {
+    // Search Drive by name (and optionally MIME type). Returns newest match or null.
+    var query = "title = '" + name.replace(/'/g, "\\'") + "'";
+    if (mimeType) query += " and mimeType = '" + mimeType + "'";
+    var iter = DriveApp.searchFiles(query);
+    var best = null;
+    while (iter.hasNext()) {
+      var f = iter.next();
+      if (!best || f.getLastUpdated() > best.getLastUpdated()) best = f;
+    }
+    return best ? best.getId() : null;
+  }
+
   function _escapeAstral(str) {
     if (!str) return str;
     return str.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, function(pair) {

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -79,7 +79,7 @@ curl -s -L -X POST 'YOUR_DEPLOYMENT_URL' \
 | `contacts.list` | List contacts | `count` (default: 20) |
 | `docs.create` | Create Google Doc | `title` (+ `body`) |
 | `drive.create` | Create file | `name` (+ `type`, `content`, `mime`) |
-| `drive.download` | Download file as base64 | `id` |
+| `drive.download` | Download file as base64 | `id` or `name` |
 | `drive.list` | List/search files | `query`, `count` (default: 10) |
 | `drive.upload` | Upload base64 file | `name`, `data_base64` (+ `mime`, `folder_id`) |
 | `fetch` | HTTP proxy (disabled by default) | `url` (+ `method`, `headers`, `payload`, `contentType`) |
@@ -96,10 +96,10 @@ curl -s -L -X POST 'YOUR_DEPLOYMENT_URL' \
 | `gmail.search` | Search email threads | `query` (default: `is:unread`), `count` (default: 10) |
 | `gmail.send` | Send email | `to` (+ `subject`, `body`, `cc`, `bcc`, `html`, `replyTo`, `inlineImages`, `driveImages`, `attachments`) |
 | `info` | Health check, list actions | -- |
-| `sheets.append` | Append rows | `spreadsheet_id`, `rows` (+ `sheet`) |
+| `sheets.append` | Append rows | `spreadsheet_id` or `name`, `rows` (+ `sheet`) |
 | `sheets.create` | Create spreadsheet | `name` (+ `headers`) |
-| `sheets.read` | Read spreadsheet | `spreadsheet_id` (+ `range`) |
-| `sheets.update` | Write values to range | `spreadsheet_id`, `range`, `values` |
+| `sheets.read` | Read spreadsheet | `spreadsheet_id` or `name` (+ `range`) |
+| `sheets.update` | Write values to range | `spreadsheet_id` or `name`, `range`, `values` |
 | `tasks.create` | Create a task | `title` (+ `list_id`, `notes`, `due`, `status`) |
 | `tasks.list` | List Google Tasks | -- (requires Tasks API enabled) |
 | `tasks.update` | Update a task | `task_id`, `list_id` (+ `title`, `notes`, `status`, `due`) |
@@ -109,6 +109,21 @@ curl -s -L -X POST 'YOUR_DEPLOYMENT_URL' \
 Every request is a JSON POST with at minimum `{"action": "...", "key": "..."}`.
 
 Every response is JSON with either the result or `{"error": "..."}`.
+
+### Name Resolution
+
+Actions that normally require an ID (`spreadsheet_id`, `id`) also accept `name` as an alternative. The bridge searches Drive for a file with that exact title and uses the newest match. This saves a round-trip compared to calling `drive.list` first.
+
+```bash
+# These are equivalent:
+gas sheets.read spreadsheet_id=1wCyx...
+gas sheets.read name=Tadpole
+
+# Works for drive.download too:
+gas drive.download name="My File.pdf"
+```
+
+If multiple files share the same name, the most recently updated one is used.
 
 ## Security
 


### PR DESCRIPTION
## Summary

- New `_resolveByName(name, mimeType)` helper searches Drive by title, returns newest match
- **sheets.read**, **sheets.update**, **sheets.append**: accept `name` alongside `spreadsheet_id`
- **drive.download**: accept `name` alongside `id`
- If multiple files share the same name, most recently updated wins
- Saves a client round-trip vs calling `drive.list` first

## Usage

```bash
# Before (two calls):
id=$(gas drive.list 'query=title = "Tadpole"' | jq -r '.files[0].id')
gas sheets.read spreadsheet_id=$id

# After (one call):
gas sheets.read name=Tadpole
```

## Test plan

- [ ] Deploy and test: `gas sheets.read name=Tadpole` returns rows
- [ ] Test with non-existent name returns error
- [ ] Test drive.download by name

🤖 Generated with [Claude Code](https://claude.com/claude-code)