### PR TITLE
Fix gmail.get plain text truncation

### DIFF
--- a/bridge/Code.js
+++ b/bridge/Code.js
@@ -488,7 +488,7 @@ var Bridge = (function() {
         to: m.getTo(),
         cc: m.getCc(),
         date: m.getDate().toISOString(),
-        plain: m.getPlainBody().substring(0, 300),
+        plain: m.getPlainBody(),
         html: m.getBody(),
         attachments: m.getAttachments().map(function(a) {
           return {name: a.getName(), type: a.getContentType(), size: a.getSize()};


### PR DESCRIPTION
One-line fix: remove .substring(0, 300) from getPlainBody() in _gmailGet. Full email text was being cut to 300 chars.