### PR TITLE
Add version tracking to info response

### DIFF
--- a/bridge/Code.js
+++ b/bridge/Code.js
@@ -601,7 +601,7 @@ var Bridge = (function() {
   function _info(req) {
     return _json({
       service: 'GAS Bridge',
-      version: '2.0',
+      version: '2.3',
       account: Session.getActiveUser().getEmail(),
       actions: Object.keys(HANDLERS),
       timestamp: new Date().toISOString()


### PR DESCRIPTION
Bumps version to 2.3 so we can tell which deployment is running.