### PR TITLE
drive.list: support folder_id param (v2.5)

### DIFF
--- a/bridge/Code.js
+++ b/bridge/Code.js
@@ -1,5 +1,5 @@
 /*
- * GAS Bridge v2.4 — Turn Google Apps Script Into a Key-Based API
+ * GAS Bridge v2.5 — Turn Google Apps Script Into a Key-Based API
  *
  * Deploys as a Web App and exposes Google Workspace services (Gmail, Drive,
  * Sheets, Calendar, Docs, Contacts, Translate, and Tasks) via simple JSON POST
@@ -265,6 +265,12 @@ var Bridge = (function() {
   function _driveList(req) {
     var files = [], count = req.count || 10;
     var query = req.query || '';
+
+    // If folder_id is provided, scope results to that folder
+    if (req.folder_id) {
+      var parentClause = "'" + req.folder_id + "' in parents";
+      query = query ? (parentClause + ' and ' + query) : parentClause;
+    }
 
     // Detect if the query specifically targets folders via mimeType
     var folderMime = "application/vnd.google-apps.folder";
@@ -643,7 +649,7 @@ var Bridge = (function() {
   function _info(req) {
     return _json({
       service: 'GAS Bridge',
-      version: '2.4',
+      version: '2.5',
       account: Session.getActiveUser().getEmail(),
       actions: Object.keys(HANDLERS),
       timestamp: new Date().toISOString()

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -82,7 +82,7 @@ curl -s -L -X POST 'YOUR_DEPLOYMENT_URL' \
 | `drive.delete` | Trash a file or folder | `id` |
 | `drive.download` | Download file as base64 | `id` or `name` |
 | `drive.folders` | List/search/create folders | `query`, `count` (+ `create`, `parent_id`) |
-| `drive.list` | List/search files and folders | `query`, `count` (default: 10) |
+| `drive.list` | List/search files and folders | `query`, `count` (+ `folder_id` to scope to a folder) |
 | `drive.upload` | Upload base64 file (always creates) | `name`, `data_base64` (+ `mime`, `folder_id`) |
 | `drive.upsert` | Upload or replace by name | `name`, `data_base64` (+ `mime`, `folder_id`) |
 | `fetch` | HTTP proxy (disabled by default) | `url` (+ `method`, `headers`, `payload`, `contentType`) |


### PR DESCRIPTION
## Summary
`drive.list` now accepts `folder_id` to scope results to a specific folder.
Previously you had to manually construct `query="'<id>' in parents"`.

## PR Checklist
- [x] Version bumped in `_info()` response (2.5)
- [x] Version bumped in header comment (v2.5)
- [x] README updated (folder_id documented)
- [x] Critic review: self-reviewed, small diff (6 lines)

## Usage
```bash
gas drive.list folder_id=1NZaekzrn1CwhRdRLwQXx-3dEfme0LH26
gas drive.list folder_id=abc123 'query=title contains "emails"'
```