### PR TITLE
Prune stale Script Properties on day rollover

### DIFF
--- a/bridge/Code.js
+++ b/bridge/Code.js
@@ -1,5 +1,5 @@
 /*
- * GAS Bridge v2.9 — Turn Google Apps Script Into a Key-Based API
+ * GAS Bridge v2.10 — Turn Google Apps Script Into a Key-Based API
  *
  * Exposes Google Workspace services (Gmail, Drive, Sheets, Calendar, Docs,
  * Contacts, Translate, and Tasks) via simple JSON POST
@@ -49,6 +49,7 @@ var Bridge = (function() {
       if (!handler) {
         return _json({error: 'unknown action', available: Object.keys(HANDLERS)});
       }
+      try { _pruneStaleProperties(); } catch (e) { /* pruning must never break requests */ }
       var result = handler(req);
       // Track usage counter per service per day (never break the request)
       try {
@@ -655,7 +656,7 @@ var Bridge = (function() {
   function _info(req) {
     return _json({
       service: 'GAS Bridge',
-      version: '2.9',
+      version: '2.10',
       account: Session.getActiveUser().getEmail(),
       actions: Object.keys(HANDLERS),
       timestamp: new Date().toISOString()
@@ -904,6 +905,28 @@ var Bridge = (function() {
 
   function _isEnabled(property) {
     return PropertiesService.getScriptProperties().getProperty(property) === 'true';
+  }
+
+  // Prune stale `_usage_<service>_<date>` and `_log_sheet_<date>` properties
+  // older than 7 days. Gated on day rollover via `_usage_last_date` so this is
+  // a cheap no-op on subsequent requests the same UTC day.
+  function _pruneStaleProperties() {
+    var props = PropertiesService.getScriptProperties();
+    var today = Utilities.formatDate(new Date(), 'UTC', 'yyyy-MM-dd');
+    if (props.getProperty('_usage_last_date') === today) return;
+
+    var cutoff = new Date();
+    cutoff.setUTCDate(cutoff.getUTCDate() - 7);
+    var cutoffStr = Utilities.formatDate(cutoff, 'UTC', 'yyyy-MM-dd');
+
+    var all = props.getProperties();
+    Object.keys(all).forEach(function(k) {
+      var m = k.match(/^(?:_usage_[A-Za-z.]+|_log_sheet)_(\d{4}-\d{2}-\d{2})$/);
+      if (m && m[1] < cutoffStr) {
+        props.deleteProperty(k);
+      }
+    });
+    props.setProperty('_usage_last_date', today);
   }
 
   function _logRequest(action, req, result) {

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -148,6 +148,8 @@ The **email read/write** quota is the one you'll hit first. Every `gmail.search`
 
 Use `gas quota` to check remaining email quota at any time. If you hit the ceiling, enable `token.get` and call the [Gmail REST API](https://developers.google.com/gmail/api/reference/rest) directly — that uses the Gmail API's own quota (250 units/second) instead of the Apps Script pool.
 
+Stale `_usage_*` and `_log_sheet_*` properties older than 7 days are pruned automatically on day rollover, so the 500 KB Script Properties ceiling stays well clear of leaked daily counters. The `quota` action's manual cleanup remains as a catch-all but is no longer required for routine operation. The day-rollover check runs at most once per UTC day per request.
+
 **References:**
 - [Apps Script Quotas](https://developers.google.com/apps-script/guides/services/quotas) — full daily limits table
 - [GmailApp Reference](https://developers.google.com/apps-script/reference/gmail/gmail-app) — GmailApp methods and per-method notes


### PR DESCRIPTION
## Summary

The bridge writes a fresh Script Property every request and every new logging day:

- `_usage_<service>_<YYYY-MM-DD>` — incremented on every `doPost` (the usage-counter block).
- `_log_sheet_<YYYY-MM-DD>` — set the first time `_logRequest` runs each new day, caching that day's log spreadsheet ID.

Neither is ever deleted automatically. The `quota` action does have a sweep, but it has to be invoked manually. Script Properties has a hard 500 KB ceiling, so an active bridge would eventually wedge.

## Fix

One new helper, `_pruneStaleProperties()`, called once per request from `doPost`:

- Gated on day rollover via a new `_usage_last_date` property — cheap no-op on every request after the first one each UTC day.
- On rollover, sweeps any `_usage_*_<date>` or `_log_sheet_<date>` property whose date suffix is older than **7 days**. Today's keys and the past week stay (so `quota`'s reporting still has recent data); older keys are deleted.
- The call site in `doPost` is wrapped in `try { ... } catch (e) {}` so a pruning failure can never break a request, matching the pattern used by the existing usage-counter block.

The `_quota` handler's own cleanup is left intact as a catch-all fallback. Version bumped to v2.10.

## Test plan

- [ ] Deploy v2.10 via Apps Script editor.
- [ ] `gas info` once on day N. Script Properties shows new `_usage_<service>_<today>` and `_usage_last_date = <today>`.
- [ ] Inject an old key manually via the editor: `_usage_gmail_2026-04-01 = 5`.
- [ ] `gas info` again on a fresh UTC day. Confirm the old key is gone, today's stays.
- [ ] Run the existing `_quota` action — should be a no-op on properties already pruned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)