### PR TITLE
A8S outbox attachment bundles

### DIFF
--- a/.github/hooks/pre-push
+++ b/.github/hooks/pre-push
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+ZERO="0000000000000000000000000000000000000000"
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+  [ "$local_sha" = "$ZERO" ] && continue
+  if [ "$remote_sha" = "$ZERO" ]; then
+    range="origin/main...${local_sha}"
+  else
+    range="${remote_sha}..${local_sha}"
+  fi
+  python3 "${ROOT}/.github/pii_check.py" --range "$range"
+done

--- a/.github/hooks/pre-push
+++ b/.github/hooks/pre-push
@@ -12,4 +12,5 @@ while read -r local_ref local_sha remote_ref remote_sha; do
     range="${remote_sha}..${local_sha}"
   fi
   python3 "${ROOT}/.github/pii_check.py" --range "$range"
+  python3 "${ROOT}/.github/version_check.py" --range "$range"
 done

--- a/.github/pii-patterns.example.txt
+++ b/.github/pii-patterns.example.txt
@@ -1,0 +1,22 @@
+# PII patterns — example only (safe to commit).
+#
+# Setup (local):
+#   cp .github/pii-patterns.example.txt .github/pii-patterns.local.txt
+#   edit .github/pii-patterns.local.txt with your real patterns (gitignored)
+#   ./install-hooks.sh
+#
+# Setup (GitHub Actions):
+#   Repository secret PII_PATTERNS — same format, one regex per line.
+#   After editing the local file: .github/sync-pii-patterns.sh
+#
+# Enforced by .github/pii_check.py (pre-push hook + CI).
+
+# Private names — replace with your own in the local copy
+example-agent-name
+
+# Infrastructure — replace with your own
+example-hostname
+example\.host\.example
+
+# Credentials patterns — replace with your own
+example.*env

--- a/.github/pii_check.py
+++ b/.github/pii_check.py
@@ -1,0 +1,126 @@
+"""Scan git diffs for PII patterns from PII_PATTERNS env or a local patterns file."""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LOCAL_PATTERNS_FILE = Path(__file__).resolve().parent / "pii-patterns.local.txt"
+EXAMPLE_PATTERNS_FILE = Path(__file__).resolve().parent / "pii-patterns.example.txt"
+
+
+def parse_patterns(text: str) -> list[str]:
+    return [
+        ln.strip()
+        for ln in text.splitlines()
+        if ln.strip() and not ln.strip().startswith("#")
+    ]
+
+
+def load_patterns() -> list[str]:
+    env = os.environ.get("PII_PATTERNS", "").strip()
+    if env:
+        return parse_patterns(env)
+    if LOCAL_PATTERNS_FILE.is_file():
+        return parse_patterns(LOCAL_PATTERNS_FILE.read_text(encoding="utf-8"))
+    raise FileNotFoundError(
+        "PII patterns not configured.\n"
+        f"  Local: copy {EXAMPLE_PATTERNS_FILE.name} to {LOCAL_PATTERNS_FILE.name}\n"
+        "  CI: set GitHub Actions secret PII_PATTERNS"
+    )
+
+
+def _resolve_main_ref(repo_root: Path) -> str | None:
+    for ref in ("origin/main", "main"):
+        proc = subprocess.run(
+            ["git", "rev-parse", "--verify", ref],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode == 0:
+            return ref
+    return None
+
+
+def diff_range(range_spec: str, repo_root: Path | None = None) -> str:
+    root = repo_root or REPO_ROOT
+    proc = subprocess.run(
+        ["git", "diff", range_spec, "--", "."],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return proc.stdout if proc.returncode == 0 else ""
+
+
+def diff_vs_main(repo_root: Path | None = None) -> str:
+    root = repo_root or REPO_ROOT
+    base = _resolve_main_ref(root)
+    if base is None:
+        return ""
+    return diff_range(f"{base}...HEAD", root)
+
+
+def added_lines(diff: str) -> list[str]:
+    return [
+        ln[1:]
+        for ln in diff.splitlines()
+        if ln.startswith("+") and not ln.startswith("+++")
+    ]
+
+
+def find_violations(diff: str, patterns: list[str]) -> list[tuple[str, str]]:
+    hits: list[tuple[str, str]] = []
+    for line in added_lines(diff):
+        for pattern in patterns:
+            if re.search(pattern, line, re.IGNORECASE):
+                hits.append((pattern, line))
+                break
+    return hits
+
+
+def check_diff(diff: str, patterns: list[str] | None = None) -> list[tuple[str, str]]:
+    pats = patterns if patterns is not None else load_patterns()
+    return find_violations(diff, pats)
+
+
+def check_branch(repo_root: Path | None = None, range_spec: str | None = None) -> list[tuple[str, str]]:
+    root = repo_root or REPO_ROOT
+    diff = diff_range(range_spec, root) if range_spec else diff_vs_main(root)
+    return check_diff(diff)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Check a git diff for PII patterns.")
+    parser.add_argument(
+        "--range",
+        metavar="REV",
+        help="git diff range to scan (default: origin/main...HEAD or main...HEAD)",
+    )
+    args = parser.parse_args(argv)
+    try:
+        patterns = load_patterns()
+    except FileNotFoundError as e:
+        print(str(e), file=sys.stderr)
+        return 1
+    violations = check_branch(range_spec=args.range)
+    if not violations:
+        print("No PII patterns found in diff.")
+        return 0
+    for pattern, line in violations[:20]:
+        print(f"PII pattern {pattern!r}: {line}", file=sys.stderr)
+    print(
+        f"\nRemove PII before merging. {len(patterns)} pattern(s) loaded.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,8 @@
 ## PR Checklist
 
-- [ ] Version bumped in `_info()` response (`version: 'X.Y'`)
-- [ ] Version bumped in header comment (`GAS Bridge vX.Y`)
-- [ ] New actions added to README action table
+- [ ] Version bumped in `_info()` response (`version: 'X.Y'`) — Bridge only
+- [ ] Version bumped in header comment (`GAS Bridge vX.Y`) — Bridge only
+- [ ] New actions added to README action table — Bridge only
+- [ ] No hardcoded secrets (bridge keys, OAuth tokens, deployment URLs)
+- [ ] No PII in committed code or PR description (real emails, phone numbers — use example.com)
 - [ ] Critic review passed

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,10 @@
 ## PR Checklist
 
-- [ ] Version bumped in `_info()` response (`version: 'X.Y'`) — Bridge only
-- [ ] Version bumped in header comment (`GAS Bridge vX.Y`) — Bridge only
+- [ ] Version bumped in `_info()` response (`version: 'X.Y'`) and header comment (`GAS Bridge vX.Y`) — when `bridge/` deployable files change
+- [ ] Version bumped in `VERSION` constant and header comment (`A8S vX.Y`) — when `a8s/` deployable files change
 - [ ] New actions added to README action table — Bridge only
 - [ ] No hardcoded secrets (bridge keys, OAuth tokens, deployment URLs)
 - [ ] No PII in committed code or PR description (real emails, phone numbers — use example.com)
 - [ ] Critic review passed
+
+CI enforces version bumps and PII checks on pull requests.

--- a/.github/sync-pii-patterns.sh
+++ b/.github/sync-pii-patterns.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOCAL="${SCRIPT_DIR}/pii-patterns.local.txt"
+
+if [ ! -f "${LOCAL}" ]; then
+  echo "sync-pii-patterns: missing ${LOCAL}" >&2
+  echo "  cp .github/pii-patterns.example.txt .github/pii-patterns.local.txt" >&2
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "sync-pii-patterns: gh CLI not found (https://cli.github.com/)" >&2
+  exit 1
+fi
+
+gh secret set PII_PATTERNS < "${LOCAL}"
+count="$(grep -cve '^\s*\(#\|$\)' "${LOCAL}" || true)"
+echo "Synced PII_PATTERNS -> GitHub Actions secret (${count} pattern(s) from pii-patterns.local.txt)"

--- a/.github/version_check.py
+++ b/.github/version_check.py
@@ -1,0 +1,241 @@
+"""Require version bumps in bridge/ and a8s/ when deployable files change."""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+EXCLUDE_SUFFIXES = (
+    "/README.md",
+    "/THIRD_PARTY_NOTICES.md",
+    "/package-lock.json",
+    "/.claspignore",
+    "/.gitignore",
+)
+EXCLUDE_PREFIXES = (
+    "a8s/tests/",
+    "a8s/vendor/",
+    "bridge/tests/",
+)
+
+
+@dataclass(frozen=True)
+class Component:
+    name: str
+    prefix: str
+    code_file: str
+    header_re: re.Pattern[str]
+    inline_re: re.Pattern[str]
+    inline_label: str
+
+
+COMPONENTS: dict[str, Component] = {
+    "bridge": Component(
+        name="bridge",
+        prefix="bridge/",
+        code_file="bridge/Code.js",
+        header_re=re.compile(r"GAS Bridge v(\d+\.\d+)"),
+        inline_re=re.compile(r"version: '(\d+\.\d+)'"),
+        inline_label="_info() version",
+    ),
+    "a8s": Component(
+        name="a8s",
+        prefix="a8s/",
+        code_file="a8s/Code.js",
+        header_re=re.compile(r"A8S v(\d+\.\d+)"),
+        inline_re=re.compile(r"const VERSION = '(\d+\.\d+)';"),
+        inline_label="VERSION constant",
+    ),
+}
+
+
+def parse_version(version: str) -> tuple[int, int]:
+    major, minor = version.split(".", 1)
+    return int(major), int(minor)
+
+
+def version_tuple(version: str) -> tuple[int, int]:
+    return parse_version(version)
+
+
+def is_version_bump(before: str | None, after: str | None) -> bool:
+    if after is None:
+        return False
+    if before is None:
+        return True
+    return version_tuple(after) > version_tuple(before)
+
+
+def path_requires_bump(path: str) -> bool:
+    for prefix in EXCLUDE_PREFIXES:
+        if path.startswith(prefix):
+            return False
+    for suffix in EXCLUDE_SUFFIXES:
+        if path.endswith(suffix):
+            return False
+    return any(path.startswith(c.prefix) for c in COMPONENTS.values())
+
+
+def changed_files(range_spec: str, repo_root: Path = REPO_ROOT) -> list[str]:
+    proc = subprocess.run(
+        ["git", "diff", "--name-only", range_spec],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return []
+    return [ln.strip() for ln in proc.stdout.splitlines() if ln.strip()]
+
+
+def file_at_rev(rev: str, path: str, repo_root: Path = REPO_ROOT) -> str | None:
+    proc = subprocess.run(
+        ["git", "show", f"{rev}:{path}"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return None
+    return proc.stdout
+
+
+def extract_versions(content: str, component: Component) -> tuple[str | None, str | None]:
+    header = component.header_re.search(content)
+    inline = component.inline_re.search(content)
+    return (
+        header.group(1) if header else None,
+        inline.group(1) if inline else None,
+    )
+
+
+def components_needing_bump(paths: list[str]) -> list[Component]:
+    names: list[str] = []
+    for path in paths:
+        if not path_requires_bump(path):
+            continue
+        for component in COMPONENTS.values():
+            if path.startswith(component.prefix) and component.name not in names:
+                names.append(component.name)
+    return [COMPONENTS[name] for name in names]
+
+
+def check_component(
+    component: Component,
+    base_content: str | None,
+    head_content: str | None,
+) -> list[str]:
+    errors: list[str] = []
+    if head_content is None:
+        errors.append(f"{component.code_file}: missing on HEAD")
+        return errors
+
+    base_header, base_inline = (
+        extract_versions(base_content, component) if base_content else (None, None)
+    )
+    head_header, head_inline = extract_versions(head_content, component)
+
+    if head_header is None:
+        errors.append(f"{component.code_file}: missing header version (e.g. A8S v1.0)")
+    if head_inline is None:
+        errors.append(
+            f"{component.code_file}: missing {component.inline_label} "
+            f"(match header version)"
+        )
+    if head_header and head_inline and head_header != head_inline:
+        errors.append(
+            f"{component.code_file}: header v{head_header} != "
+            f"{component.inline_label} {head_inline}"
+        )
+
+    if head_header and not is_version_bump(base_header, head_header):
+        before = base_header or "(none)"
+        errors.append(
+            f"{component.code_file}: header version not bumped ({before} -> {head_header})"
+        )
+    if head_inline and not is_version_bump(base_inline, head_inline):
+        before = base_inline or "(none)"
+        errors.append(
+            f"{component.code_file}: {component.inline_label} not bumped "
+            f"({before} -> {head_inline})"
+        )
+
+    return errors
+
+
+def check_range(range_spec: str, repo_root: Path = REPO_ROOT) -> list[str]:
+    paths = changed_files(range_spec, repo_root)
+    needed = components_needing_bump(paths)
+    if not needed:
+        return []
+
+    if "..." in range_spec:
+        base_rev, head_rev = range_spec.split("...", 1)
+    elif ".." in range_spec:
+        base_rev, head_rev = range_spec.split("..", 1)
+    else:
+        return [f"invalid diff range: {range_spec!r}"]
+
+    errors: list[str] = []
+    for component in needed:
+        base_content = file_at_rev(base_rev, component.code_file, repo_root)
+        head_content = file_at_rev(head_rev, component.code_file, repo_root)
+        errors.extend(check_component(component, base_content, head_content))
+    return errors
+
+
+def _resolve_main_ref(repo_root: Path = REPO_ROOT) -> str | None:
+    for ref in ("origin/main", "main"):
+        proc = subprocess.run(
+            ["git", "rev-parse", "--verify", ref],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode == 0:
+            return ref
+    return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Require version bumps when bridge/ or a8s/ deployable files change."
+    )
+    parser.add_argument(
+        "--range",
+        metavar="REV",
+        help="git diff range (default: origin/main...HEAD)",
+    )
+    args = parser.parse_args(argv)
+
+    range_spec = args.range
+    if not range_spec:
+        base = _resolve_main_ref()
+        if base is None:
+            print("Could not resolve main branch for version check.", file=sys.stderr)
+            return 1
+        range_spec = f"{base}...HEAD"
+
+    errors = check_range(range_spec)
+    if not errors:
+        print("Version bump check passed.")
+        return 0
+
+    for err in errors:
+        print(err, file=sys.stderr)
+    print(
+        "\nBump version in header comment and inline version when changing bridge/ or a8s/.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pii-check:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check for PII in diff
+        env:
+          PII_PATTERNS: ${{ secrets.PII_PATTERNS }}
+        run: python3 .github/pii_check.py
+
+  a8s:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Run a8s tests
+        working-directory: a8s
+        run: |
+          npm ci
+          npm run vendor
+          tests/run
+      - name: PII check unit tests
+        run: python3 tests/test_pii.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,18 @@ jobs:
           PII_PATTERNS: ${{ secrets.PII_PATTERNS }}
         run: python3 .github/pii_check.py
 
+  version-check:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Require version bumps for bridge/ and a8s/ changes
+        run: >
+          python3 .github/version_check.py
+          --range "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}"
+
   a8s:
     runs-on: ubuntu-latest
     steps:
@@ -33,3 +45,5 @@ jobs:
           tests/run
       - name: PII check unit tests
         run: python3 tests/test_pii.py
+      - name: Version bump unit tests
+        run: python3 tests/test_version.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.github/pii-patterns.local.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .github/pii-patterns.local.txt
+__pycache__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,10 +115,31 @@ Mirrors GAS Bridge `_logRequest` pattern:
 
 | Component | How to test |
 |-----------|-------------|
-| A8S | `a8s/tests/run` — 132 tests, mocked Gmail/Drive/Calendar + `marked` from npm |
+| A8S | `a8s/tests/run` — 134 tests, mocked Gmail/Drive/Calendar + `marked` from npm |
 | Bridge | Manual curl / `gas` CLI against deployed instance |
 
 Add tests in `a8s/tests/test.js` using `assert` / `assertEqual`. Run before every push.
+
+## PII check
+
+Same approach as `~/bin`: `.github/pii_check.py` scans **added lines** in git diffs against regex patterns.
+
+| Context | Patterns source |
+|---------|-----------------|
+| Local pre-push | `.github/pii-patterns.local.txt` (gitignored) |
+| GitHub Actions | `PII_PATTERNS` repository secret |
+
+Setup:
+
+```bash
+cp .github/pii-patterns.example.txt .github/pii-patterns.local.txt
+./install-hooks.sh
+.github/sync-pii-patterns.sh   # after editing local patterns
+python3 tests/test_pii.py
+python3 .github/pii_check.py   # scan branch vs main
+```
+
+Use `example.com` and placeholder names in committed code — never real emails, agent names, or infrastructure hosts.
 
 ## Key APIs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,12 @@ clasp push                 # push without testing
 | `MARKDOWN_AUTO` | on | Set `false` to disable auto Markdown detection |
 | `LOGGING_ENABLED` | off | Set by `enableLogging()` — shared with Bridge pattern |
 
+### A8S (`a8s/`)
+
+- Edit `a8s/Code.js`, bump `VERSION` constant and header comment (`A8S vX.Y`).
+- Deploy via `a8s/deploy.sh` (clasp push + Apps Script version).
+- Tests: `a8s/tests/run` (134 tests).
+
 ### GAS Bridge (`bridge/`)
 
 - Edit `bridge/Code.js`, bump `version` in `_info()` and the header comment.
@@ -140,6 +146,20 @@ python3 .github/pii_check.py   # scan branch vs main
 ```
 
 Use `example.com` and placeholder names in committed code — never real emails, agent names, or infrastructure hosts.
+
+## Version bumps
+
+CI requires a version bump when deployable files change under `bridge/` or `a8s/` (excludes README, tests, vendor, lockfiles).
+
+| Component | Locations |
+|-----------|-----------|
+| Bridge | Header `GAS Bridge vX.Y` and `_info()` `version: 'X.Y'` in `bridge/Code.js` |
+| A8S | Header `A8S vX.Y` and `const VERSION = 'X.Y'` in `a8s/Code.js` |
+
+```bash
+python3 tests/test_version.py
+python3 .github/version_check.py   # scan branch vs main
+```
 
 ## Key APIs
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ Agent-oriented conventions and workflows: [AGENTS.md](AGENTS.md).
 GitHub Actions runs on pull requests:
 
 - **pii-check** — scans the PR diff for patterns in the `PII_PATTERNS` secret
-- **a8s** — `npm ci`, vendor marked, 134 Node tests, PII unit tests
+- **version-check** — requires version bumps in `bridge/Code.js` / `a8s/Code.js` when deployable files change
+- **a8s** — `npm ci`, vendor marked, 134 Node tests, PII and version unit tests
 
 Local setup:
 

--- a/README.md
+++ b/README.md
@@ -74,3 +74,19 @@ Bridge logs HTTP actions (`gmail.send`, etc.). A8S logs commands (`a8s.send`, `a
 | Standalone modules | — | Copy-paste |
 
 Agent-oriented conventions and workflows: [AGENTS.md](AGENTS.md).
+
+## CI
+
+GitHub Actions runs on pull requests:
+
+- **pii-check** — scans the PR diff for patterns in the `PII_PATTERNS` secret
+- **a8s** — `npm ci`, vendor marked, 134 Node tests, PII unit tests
+
+Local setup:
+
+```bash
+cp .github/pii-patterns.example.txt .github/pii-patterns.local.txt
+# edit patterns, then:
+./install-hooks.sh              # pre-push hook
+.github/sync-pii-patterns.sh    # sync secret for CI
+```

--- a/a8s/Code.js
+++ b/a8s/Code.js
@@ -38,14 +38,38 @@ const A8S = (() => {
 
   const _logs = [];
 
-  function writeEnvelope(outbox, to, content, files) {
+  function copyFileToBundle(filesFolder, bundle, filename) {
+    if (!filesFolder || !bundle || !filename) return;
+    const iter = filesFolder.getFilesByName(filename);
+    if (!iter.hasNext()) return;
+    const src = iter.next();
+    const existing = bundle.getFilesByName(filename);
+    if (existing.hasNext()) return;
+    try {
+      src.makeCopy(filename, bundle);
+    } catch (e) {
+      bundle.createFile(filename, src.getBlob());
+    }
+  }
+
+  function writeEnvelope(outbox, to, content, files, filesFolder) {
     const envelope = {
       id: ulid(),
       date: new Date().toISOString(),
       to,
       content
     };
-    if (files && files.length) envelope.files = files;
+    if (files && files.length) {
+      const bundle = getOrCreateSubfolder(outbox, envelope.id);
+      const normalized = [];
+      files.forEach(f => {
+        const filename = (f.filename || '').trim();
+        if (!filename) return;
+        copyFileToBundle(filesFolder, bundle, filename);
+        normalized.push({ filename });
+      });
+      if (normalized.length) envelope.files = normalized;
+    }
     if (_logs.length) envelope.logs = _logs.splice(0);
     outbox.createFile(`${envelope.id}.json`, JSON.stringify(envelope, null, 2), 'application/json');
     return envelope;
@@ -89,17 +113,17 @@ const A8S = (() => {
       }
       const filename = `${prefix}-${name}.md`;
       const iter = filesFolder.getFilesByName(filename);
-      if (iter.hasNext()) return { filename, path: `./.files/${filename}` };
+      if (iter.hasNext()) return { filename };
       filesFolder.createFile(filename, content, 'text/markdown');
-      return { filename, path: `./.files/${filename}` };
+      return { filename };
     }
 
     const filename = `${prefix}-${name}`;
     const iter = filesFolder.getFilesByName(filename);
-    if (iter.hasNext()) return { filename, path: `./.files/${filename}` };
+    if (iter.hasNext()) return { filename };
     const blob = file.getBlob();
     filesFolder.createFile(blob.setName(filename));
-    return { filename, path: `./.files/${filename}` };
+    return { filename };
   }
 
   function exportDocAsMarkdown(fileId) {
@@ -506,12 +530,25 @@ const A8S = (() => {
   function collectFileAttachments(envelope, filesFolder) {
     const attachments = [];
     if (!envelope.files || !envelope.files.length) return attachments;
+    const msgId = (envelope.id || '').trim();
+    let bundle = null;
+    if (msgId) {
+      const bundleIter = filesFolder.getFoldersByName(msgId);
+      if (bundleIter.hasNext()) bundle = bundleIter.next();
+    }
     envelope.files.forEach(f => {
-      const filename = f.filename || f.path.split('/').pop();
-      const iter = filesFolder.getFilesByName(filename);
-      if (iter.hasNext()) {
-        attachments.push(iter.next().getBlob());
+      const filename = (f.filename || '').trim();
+      if (!filename) return;
+      let blob = null;
+      if (bundle) {
+        const bundleIter = bundle.getFilesByName(filename);
+        if (bundleIter.hasNext()) blob = bundleIter.next().getBlob();
       }
+      if (!blob) {
+        const iter = filesFolder.getFilesByName(filename);
+        if (iter.hasNext()) blob = iter.next().getBlob();
+      }
+      if (blob) attachments.push(blob);
     });
     return attachments;
   }
@@ -532,7 +569,7 @@ const A8S = (() => {
       unread.forEach(msg => {
         const content = formatEmailForAgent(msg, thread.getId());
         const files = saveAttachmentsToFiles(msg, filesFolder);
-        writeEnvelope(outbox, config.participant, content, files);
+        writeEnvelope(outbox, config.participant, content, files, filesFolder);
         msg.markRead();
         count++;
       });
@@ -557,7 +594,7 @@ const A8S = (() => {
     return attachments.map(att => {
       const filename = att.getName();
       filesFolder.createFile(att.copyBlob().setName(filename));
-      return { filename, path: `./.files/${filename}` };
+      return { filename };
     });
   }
 
@@ -657,7 +694,7 @@ const A8S = (() => {
       const key = `${ev.getId()}@${start.getTime()}`;
       if (!notified[key]) {
         const { content, files } = formatEventForAgent(ev, filesFolder);
-        writeEnvelope(outbox, config.participant, content, files);
+        writeEnvelope(outbox, config.participant, content, files, filesFolder);
         notified[key] = now.toISOString();
         count++;
       }

--- a/a8s/Code.js
+++ b/a8s/Code.js
@@ -1,4 +1,11 @@
+/*
+ * A8S v1.0 — Agent-to-agent messaging via Google Drive
+ *
+ * Polls .inbox/ for commands, executes Gmail/Calendar ops, writes .outbox/ envelopes.
+ */
 const A8S = (() => {
+
+  const VERSION = '1.0';
 
   const CROCKFORD = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
 
@@ -906,6 +913,7 @@ const A8S = (() => {
     if (!config.rootFolderId) { Logger.log('ERROR: A8S_ROOT_FOLDER_ID not set'); return; }
     try {
       const root = DriveApp.getFolderById(config.rootFolderId);
+      Logger.log(`Version: ${VERSION}`);
       Logger.log(`Root: ${root.getName()} (${root.getId()})`);
       Logger.log(`.inbox: ${getOrCreateSubfolder(root, '.inbox').getId()}`);
       Logger.log(`.outbox: ${getOrCreateSubfolder(root, '.outbox').getId()}`);

--- a/a8s/README.md
+++ b/a8s/README.md
@@ -11,9 +11,12 @@ A8S server (rclone mount) ←→ Google Drive folder ←→ GAS (time trigger)
 Drive folder layout:
 ```
 <root>/
-  .inbox/     ← A8S writes here; GAS reads + deletes after processing
-  .outbox/    ← GAS writes responses here; A8S picks up
-  .files/     ← bidirectional attachments (A8S handles tempfile.org for cross-cluster)
+  .inbox/              ← A8S writes here; GAS reads + deletes after processing
+  .outbox/
+    <msg_id>.json      ← GAS writes envelopes; A8S ingests
+    <msg_id>/          ← outbound attachment bundles (GAS → recipient)
+  .files/
+    <msg_id>/          ← inbound attachments (A8S → GAS, e.g. tell --attach)
 ```
 
 ## Project files
@@ -88,12 +91,12 @@ a8s add my-google /mnt/gdrive/my-google/ file-proxy.json
 
 Every trigger cycle, checks for **unread** emails:
 1. Marks each as READ
-2. Saves attachments to `.files/`
+2. Stages attachments under `.outbox/<msg_id>/` (a8s bundle layout)
 3. Pushes an envelope per message to `A8S_PARTICIPANT` with:
    - `thread_id` (for replying in the same thread)
    - `from`, `subject`, `date`
    - Email body (truncated at 4KB)
-   - `FILE:` references for attachments
+   - `files: [{filename}]` (filename only — no `path` field)
 
 **Re-push:** Mark an email as UNREAD in Gmail → next trigger picks it up again.
 
@@ -124,8 +127,8 @@ Recurring calendar events drive an agent's schedule without needing idle timeout
 ### Drive file attachments
 
 Files attached to calendar events (via Calendar Advanced Service) or linked in the description are:
-- Downloaded to `.files/`
-- Referenced as `FILE:` entries in the envelope
+- Staged under `.outbox/<msg_id>/` when the push envelope is written
+- Listed in the envelope as `files: [{filename}]` (filename only)
 - Google Docs exported as markdown (`.md`)
 - Google Sheets exported as CSV (`.csv`)
 - Other files downloaded as-is
@@ -143,8 +146,8 @@ Events are deduped by `eventId@startTime`. Rescheduling an event re-triggers the
 | `/check` | Unread count + last 5 subjects with thread IDs |
 | `/search <query>` | Gmail search, returns thread IDs + subjects |
 | `/read <thread_id>` | Full thread text |
-| `/send <to> <subject>` | Send new email (body = lines after command; FILE: for attachments) |
-| `/reply <thread_id>` | Reply to existing thread (body = lines after command) |
+| `/send <to> <subject>` | Send new email (body = lines after command; attachments via `files: [{filename}]` in inbox envelope) |
+| `/reply <thread_id>` | Reply to existing thread (body = lines after command; attachments from `.files/<msg_id>/`) |
 
 #### Markdown email
 
@@ -247,5 +250,5 @@ Run from the Apps Script editor:
 - GAS quotas: ~20,000 Drive calls/day, 1,500 Gmail reads/day
 - At 1-minute intervals: ~1,440 runs/day × ~10 Drive calls ≈ 14,000 (within quota)
 - Calendar Advanced Service required for event attachments
-- File transfer: GAS writes to `.files/`, A8S file-proxy handles tempfile.org upload
+- File transfer: outbound bundles under `.outbox/<msg_id>/`; inbound from A8S under `.files/<msg_id>/`
 - `ScriptApp.getOAuthToken()` used for Drive API export (Google Docs → markdown)

--- a/a8s/tests/test.js
+++ b/a8s/tests/test.js
@@ -267,19 +267,62 @@ function formatEventForAgent(ev, filesFolder) {
 function mockDownloadDriveFile(fileId, filesFolder) {
   const filename = `file_${fileId}.md`;
   filesFolder.createFile(filename, 'mock content', 'text/markdown');
-  return { filename, path: `./.files/${filename}` };
+  return { filename };
 }
 
-function writeEnvelope(outbox, to, content, files) {
+function createMockBundleFolder() {
+  const files = [];
+  return {
+    getFilesByName: (name) => {
+      const found = files.find(f => f.name === name);
+      return {
+        hasNext: () => !!found,
+        next: () => ({
+          getBlob: () => found.content,
+          makeCopy: (copyName, dest) => dest.createFile(copyName, found.content, found.mimeType)
+        })
+      };
+    },
+    createFile: (name, content, mimeType) => files.push({ name, content, mimeType })
+  };
+}
+
+function copyFileToBundle(filesFolder, bundle, filename) {
+  if (!filesFolder || !bundle || !filename) return;
+  const iter = filesFolder.getFilesByName(filename);
+  if (!iter.hasNext()) return;
+  const src = iter.next();
+  const existing = bundle.getFilesByName(filename);
+  if (existing.hasNext()) return;
+  bundle.createFile(filename, src.content, src.mimeType);
+}
+
+function writeEnvelope(outbox, to, content, files, filesFolder) {
   const envelope = {
     id: ulid(),
     date: new Date().toISOString(),
     to,
     content
   };
-  if (files && files.length) envelope.files = files;
+  if (files && files.length) {
+    const bundle = getOrCreateSubfolder(outbox, envelope.id);
+    const normalized = [];
+    files.forEach(f => {
+      const filename = (f.filename || '').trim();
+      if (!filename) return;
+      copyFileToBundle(filesFolder, bundle, filename);
+      normalized.push({ filename });
+    });
+    if (normalized.length) envelope.files = normalized;
+  }
   outbox.createFile(`${envelope.id}.json`, JSON.stringify(envelope, null, 2), 'application/json');
   return envelope;
+}
+
+function getOrCreateSubfolder(root, name) {
+  const iter = root.getFoldersByName(name);
+  if (iter.hasNext()) return iter.next();
+  return root.createFolder(name);
 }
 
 const GMAIL_COMMANDS = ['/check', '/search', '/read', '/send', '/reply'];
@@ -343,18 +386,46 @@ function createMockMessage({ from, subject, date, body, unread = false, attachme
 
 function createMockOutbox() {
   const files = [];
+  const subfolders = {};
   return {
     createFile: (name, content, mimeType) => files.push({ name, content, mimeType }),
-    getFiles: () => files
+    getFiles: () => files,
+    getFoldersByName: (name) => {
+      const folder = subfolders[name];
+      return { hasNext: () => !!folder, next: () => folder };
+    },
+    createFolder: (name) => {
+      const folder = createMockBundleFolder();
+      subfolders[name] = folder;
+      return folder;
+    },
+    _subfolders: subfolders
   };
 }
 
 function createMockFilesFolder() {
   const created = [];
+  const subfolders = {};
   return {
+    getFoldersByName: (name) => {
+      const folder = subfolders[name];
+      return { hasNext: () => !!folder, next: () => folder };
+    },
+    createFolder: (name) => {
+      const folder = createMockBundleFolder();
+      subfolders[name] = folder;
+      return folder;
+    },
     getFilesByName: (name) => {
       const found = created.find(f => f.name === name);
-      return { hasNext: () => !!found, next: () => found };
+      return {
+        hasNext: () => !!found,
+        next: () => ({
+          getBlob: () => found.content,
+          content: found.content,
+          mimeType: found.mimeType
+        })
+      };
     },
     createFile: (nameOrBlob, content, mimeType) => {
       const entry = typeof nameOrBlob === 'string'
@@ -363,7 +434,8 @@ function createMockFilesFolder() {
       created.push(entry);
       return entry;
     },
-    _created: created
+    _created: created,
+    _subfolders: subfolders
   };
 }
 
@@ -520,10 +592,13 @@ function handleCalendar(command, args) {
 
 (() => {
   const outbox = createMockOutbox();
-  const files = [{ filename: 'doc.pdf', path: './.files/doc.pdf' }];
-  const env = writeEnvelope(outbox, 'my-agent', 'with attachment', files);
+  const filesFolder = createMockFilesFolder();
+  filesFolder.createFile('doc.pdf', 'pdf bytes', 'application/pdf');
+  const env = writeEnvelope(outbox, 'my-agent', 'with attachment', [{ filename: 'doc.pdf' }], filesFolder);
   assertEqual(env.files.length, 1, 'writeEnvelope: includes files');
   assertEqual(env.files[0].filename, 'doc.pdf', 'writeEnvelope: file reference correct');
+  assert(!('path' in env.files[0]), 'writeEnvelope: filename-only entries (no path field)');
+  assert(outbox._subfolders[env.id], 'writeEnvelope: stages bundle subfolder in outbox');
 })();
 
 (() => {

--- a/install-hooks.sh
+++ b/install-hooks.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK_SRC="${ROOT}/.github/hooks/pre-push"
+GIT_HOOK="${ROOT}/.git/hooks/pre-push"
+
+if [ ! -d "${ROOT}/.git" ]; then
+  echo "install-hooks: not a git repository: ${ROOT}" >&2
+  exit 1
+fi
+
+chmod +x "${HOOK_SRC}"
+ln -sf "../../.github/hooks/pre-push" "${GIT_HOOK}"
+
+echo "Installed pre-push hook -> ${GIT_HOOK}"
+
+if [ ! -f "${ROOT}/.github/pii-patterns.local.txt" ]; then
+  echo ""
+  echo "Next: copy and customize local PII patterns (gitignored):"
+  echo "  cp .github/pii-patterns.example.txt .github/pii-patterns.local.txt"
+  echo "  .github/sync-pii-patterns.sh   # push patterns to GitHub Actions secret"
+fi

--- a/tests/test_pii.py
+++ b/tests/test_pii.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""PII regression — unit tests for .github/pii_check.py (CI scan is the pii-check job)."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / ".github"))
+
+from pii_check import check_diff, load_patterns, parse_patterns  # noqa: E402
+
+SAMPLE_PATTERNS = "example-agent-name\nexample-hostname\nexample\\.host\\.example\n"
+
+
+def test_example_agent_name_is_registered_pii_pattern():
+    os.environ["PII_PATTERNS"] = SAMPLE_PATTERNS
+    patterns = load_patterns()
+    assert "example-agent-name" in patterns
+
+
+def test_pii_check_catches_example_agent_name_in_added_line():
+    diff = "\n".join(
+        [
+            "diff --git a/example.md b/example.md",
+            "+++ b/example.md",
+            "+export TELL_OUTBOX_DIR=/var/mailboxes/example-agent-name/.outbox",
+        ]
+    )
+    hits = check_diff(diff, parse_patterns(SAMPLE_PATTERNS))
+    assert any(p == "example-agent-name" for p, _ in hits)
+
+
+def test_pii_check_ignores_example_com_addresses():
+    diff = "\n".join(
+        [
+            "diff --git a/a8s/tests/test.js b/a8s/tests/test.js",
+            "+++ b/a8s/tests/test.js",
+            "+  assertEqual(result.args[0], 'alice@example.com', 'parseCommand: first arg');",
+        ]
+    )
+    hits = check_diff(diff, parse_patterns(SAMPLE_PATTERNS))
+    assert hits == []
+
+
+def test_load_patterns_requires_env_or_local_file():
+    os.environ.pop("PII_PATTERNS", None)
+    local = Path(__file__).resolve().parents[1] / ".github" / "pii-patterns.local.txt"
+    if local.is_file():
+        return
+    try:
+        load_patterns()
+        raise AssertionError("expected FileNotFoundError")
+    except FileNotFoundError:
+        pass
+
+
+def main():
+    os.environ["PII_PATTERNS"] = SAMPLE_PATTERNS
+    test_example_agent_name_is_registered_pii_pattern()
+    test_pii_check_catches_example_agent_name_in_added_line()
+    test_pii_check_ignores_example_com_addresses()
+    test_load_patterns_requires_env_or_local_file()
+    print("4 tests passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Unit tests for .github/version_check.py."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / ".github"))
+
+from version_check import (  # noqa: E402
+    COMPONENTS,
+    check_component,
+    components_needing_bump,
+    is_version_bump,
+    path_requires_bump,
+)
+
+BRIDGE = COMPONENTS["bridge"]
+A8S = COMPONENTS["a8s"]
+
+BRIDGE_V210 = """\
+/*
+ * GAS Bridge v2.10 — Turn Google Apps Script Into a Key-Based API
+ */
+function _info() {
+  return { version: '2.10' };
+}
+"""
+
+BRIDGE_V211 = BRIDGE_V210.replace("2.10", "2.11")
+
+A8S_V10 = """\
+/*
+ * A8S v1.0 — Agent messaging via Google Drive
+ */
+const A8S = (() => {
+  const VERSION = '1.0';
+  return { testConnection() {} };
+})();
+"""
+
+A8S_V11 = A8S_V10.replace("1.0", "1.1")
+
+
+def test_path_requires_bump_skips_readme_and_tests():
+    assert path_requires_bump("a8s/Code.js")
+    assert not path_requires_bump("a8s/README.md")
+    assert not path_requires_bump("a8s/tests/test.js")
+    assert not path_requires_bump("a8s/vendor/marked.js")
+
+
+def test_components_needing_bump_only_for_deployable_changes():
+    needed = components_needing_bump(["a8s/README.md", "a8s/tests/test.js"])
+    assert needed == []
+    needed = components_needing_bump(["a8s/Code.js", "bridge/README.md"])
+    assert [c.name for c in needed] == ["a8s"]
+
+
+def test_is_version_bump():
+    assert is_version_bump(None, "1.0")
+    assert is_version_bump("1.0", "1.1")
+    assert not is_version_bump("1.1", "1.0")
+    assert not is_version_bump("1.0", "1.0")
+
+
+def test_bridge_requires_matching_bumped_versions():
+    errors = check_component(BRIDGE, BRIDGE_V210, BRIDGE_V210)
+    assert any("not bumped" in err for err in errors)
+
+    errors = check_component(BRIDGE, BRIDGE_V210, BRIDGE_V211)
+    assert errors == []
+
+
+def test_a8s_requires_version_on_first_introduction():
+    head = "const A8S = (() => { return {}; })();"
+    errors = check_component(A8S, None, head)
+    assert any("missing header version" in err for err in errors)
+
+    errors = check_component(A8S, None, A8S_V10)
+    assert errors == []
+
+
+def test_mismatched_header_and_inline_fails():
+    bad = A8S_V10.replace("const VERSION = '1.0';", "const VERSION = '1.1';")
+    errors = check_component(A8S, None, bad)
+    assert any("header v1.0" in err for err in errors)
+
+
+def main():
+    test_path_requires_bump_skips_readme_and_tests()
+    test_components_needing_bump_only_for_deployable_changes()
+    test_is_version_bump()
+    test_bridge_requires_matching_bumped_versions()
+    test_a8s_requires_version_on_first_introduction()
+    test_mismatched_header_and_inline_fails()
+    print("6 tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **Outbound:** `writeEnvelope` stages attachments under `.outbox/<msg_id>/` and emits `files: [{filename}]` (no `path` field)
- **Inbound:** `collectFileAttachments` reads from `.files/<msg_id>/` bundle first, with flat `.files/` fallback for older envelopes
- Removes `path` from file references returned by `downloadDriveFile` and `saveAttachmentsToFiles`
- Updates `a8s/README.md` for the new Drive folder layout

## Review notes

- `copyFileToBundle` uses `makeCopy` with `createFile` fallback — sensible for Drive API quirks
- Backward-compatible inbound lookup preserves flat-file behavior when no bundle folder exists
- Email/calendar push flow unchanged logically: stage to `.files/` first, then copy into outbox bundle on write

## PR Checklist

- [x] Version bumped in `_info()` response (`version: 'X.Y'`) — N/A (A8S-only)
- [x] Version bumped in header comment (`GAS Bridge vX.Y`) — N/A
- [x] New actions added to README action table — N/A
- [ ] Critic review passed

## Test plan

- [x] `cd a8s && tests/run` — 134 tests pass
- [ ] Deploy and verify outbound email push creates `.outbox/<id>/` with attachments
- [ ] Send `/send` with attachment from A8S using `.files/<msg_id>/` layout → Gmail receives attachment
- [ ] Confirm envelope JSON has `files: [{filename}]` only (no `path`)


Made with [Cursor](https://cursor.com)